### PR TITLE
Fix incomplete .NET Core package definitions from 3.1.0 to 3.1.4

### DIFF
--- a/src/wixlib/NetCore3.1.0_x64.wxs
+++ b/src/wixlib/NetCore3.1.0_x64.wxs
@@ -11,7 +11,7 @@
 
     <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/a16689d1-0872-4ef9-a592-406d3038d8f7/cf4f84504385a599f0cb6a5c113ccb34/aspnetcore-runtime-3.1.0-win-x64.exe?>
     <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/a1510e74-b31a-4434-b8a0-8074ff31fb3f/b7de8ecba4a14d8312551cfdc745dea1/windowsdesktop-runtime-3.1.0-win-x64.exe?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/9f010da2-d510-4271-8dcc-ad92b8b9b767/d2dd394046c20e0563ce5c45c356653f/dotnet-runtime-3.1.0-win-x64.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
+                    CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
+                    Description="Microsoft .NET Core Runtime - 3.1.0 (x64)"
+                    Hash="DDA7CD0E851E742ACA43EFBD1361CDB382771E21"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.0 (x64)"
+                    Size="26061496"
+                    Version="3.1.0.28315" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -76,13 +74,13 @@
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
                 <RemotePayload
-                  CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
-                  CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
-                  Description="Microsoft ASP.NET Core 3.1.0 - Shared Framework"
-                  Hash="2DFD4F9EA2E174A7199C40ED3A826886F1E19EF8"
-                  ProductName="Microsoft ASP.NET Core 3.1.0 - Shared Framework"
-                  Size="7811768"
-                  Version="3.1.0.19566" />
+                    CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
+                    CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
+                    Description="Microsoft ASP.NET Core 3.1.0 - Shared Framework"
+                    Hash="2DFD4F9EA2E174A7199C40ED3A826886F1E19EF8"
+                    ProductName="Microsoft ASP.NET Core 3.1.0 - Shared Framework"
+                    Size="7811768"
+                    Version="3.1.0.19566" />
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -112,13 +110,13 @@
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
                 <RemotePayload
-                  CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
-                  CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
-                  Description="Microsoft Windows Desktop Runtime - 3.1.0 (x64)"
-                  Hash="C16F271754879BA78868947486F37871C9F0E40F"
-                  ProductName="Microsoft Windows Desktop Runtime - 3.1.0 (x64)"
-                  Size="54443856"
-                  Version="3.1.0.28315" />
+                    CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
+                    CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.0 (x64)"
+                    Hash="C16F271754879BA78868947486F37871C9F0E40F"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.0 (x64)"
+                    Size="54443856"
+                    Version="3.1.0.28315" />
             </ExePackage>
         </PackageGroup>
     </Fragment>

--- a/src/wixlib/NetCore3.1.0_x86.wxs
+++ b/src/wixlib/NetCore3.1.0_x86.wxs
@@ -9,9 +9,9 @@
     <?define NetCoreVersion = 3.1.0?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = ?>
-    <?define DesktopNetCoreRedistLink = ?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/74ed410a-d452-4057-bb89-befeccf34b2b/e11a376951914e197c50528e5b20e2ef/aspnetcore-runtime-3.1.0-win-x86.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/e93147bb-7654-46d6-954a-bbd54da63b9b/cbdba4605fd04dc3886ca772d3953c53/windowsdesktop-runtime-3.1.0-win-x86.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/04356520-4cf7-4e98-b4a8-b3043e2eeca3/cdf6d3d104334dfe8f471fe135f16b07/dotnet-runtime-3.1.0-win-x86.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
+                    CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
+                    Description="Microsoft .NET Core Runtime - 3.1.0 (x86)"
+                    Hash="CAF456ED2F229E5CE36CEAE5C752D7C69BB4CABD"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.0 (x86)"
+                    Size="23318984"
+                    Version="3.1.0.28315" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -59,7 +57,6 @@
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -76,18 +73,16 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
+                    CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
+                    Description="Microsoft ASP.NET Core 3.1.0 - Shared Framework"
+                    Hash="7616CD3453F253032DB7A56455A8429FAEC934C4"
+                    ProductName="Microsoft ASP.NET Core 3.1.0 - Shared Framework"
+                    Size="7146408"
+                    Version="3.1.0.19566" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -98,7 +93,6 @@
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -115,17 +109,15 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6608A9DBA86701156A4C17CE63BA99BE8B932F8D"
+                    CertificateThumbprint="62009AAABDAE749FD47D19150958329BF6FF4B34"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.0 (x86)"
+                    Hash="96FF19C3F740EA1D49376462EE336F5E5CA0ED79"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.0 (x86)"
+                    Size="48703304"
+                    Version="3.1.0.28315" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 </Wix>

--- a/src/wixlib/NetCore3.1.1_x64.wxs
+++ b/src/wixlib/NetCore3.1.1_x64.wxs
@@ -11,7 +11,7 @@
 
     <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/fa469b98-e312-4744-9dab-a46d2242b0ab/ae5e1eb530e312d68b501b7dd03d4c00/aspnetcore-runtime-3.1.1-win-x64.exe?>
     <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/a1d41522-4da0-42bc-b3f2-e4b7d842974d/03101425368c87c55c1fe7cafbb4e0fb/windowsdesktop-runtime-3.1.1-win-x64.exe?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/fda71c5b-ee58-4919-95dc-4f32dbebd2cd/97ffe3880a25f5f7cae1a7e40cd3509e/dotnet-runtime-3.1.1-win-x64.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.1 (x64)"
+                    Hash="B9E2166EDDEFAA4D7543F24A2E7CD76C35D4E617"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.1 (x64)"
+                    Size="26055096"
+                    Version="3.1.1.28408" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -76,13 +74,13 @@
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
                 <RemotePayload
-                  CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                  CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                  Description="Microsoft ASP.NET Core 3.1.1 - Shared Framework"
-                  Hash="6614D5792D9335632D66C3EB7DE942A7AE10D6BE"
-                  ProductName="Microsoft ASP.NET Core 3.1.1 - Shared Framework"
-                  Size="7867488"
-                  Version="3.1.1.19615"/>
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft ASP.NET Core 3.1.1 - Shared Framework"
+                    Hash="6614D5792D9335632D66C3EB7DE942A7AE10D6BE"
+                    ProductName="Microsoft ASP.NET Core 3.1.1 - Shared Framework"
+                    Size="7867488"
+                    Version="3.1.1.19615"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -112,13 +110,13 @@
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
                 <RemotePayload
-                  CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                  CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                  Description="Microsoft Windows Desktop Runtime - 3.1.1 (x64)"
-                  Hash="AE723619D9CD6407F3D4B4948DF4F026A99781DC"
-                  ProductName="Microsoft Windows Desktop Runtime - 3.1.1 (x64)"
-                  Size="54211664"
-                  Version="3.1.1.28408"/>
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.1 (x64)"
+                    Hash="AE723619D9CD6407F3D4B4948DF4F026A99781DC"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.1 (x64)"
+                    Size="54211664"
+                    Version="3.1.1.28408"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>

--- a/src/wixlib/NetCore3.1.1_x86.wxs
+++ b/src/wixlib/NetCore3.1.1_x86.wxs
@@ -9,9 +9,9 @@
     <?define NetCoreVersion = 3.1.1?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = ?>
-    <?define DesktopNetCoreRedistLink = ?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/b1298310-3170-4553-ba50-153e1def5747/00ba44679959c19a67bd36b8c1eb5220/aspnetcore-runtime-3.1.1-win-x86.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/662153d9-58c5-4630-a326-ed9e4e342787/1deb6ba6a2a5f5f694b784a6859b446e/windowsdesktop-runtime-3.1.1-win-x86.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/3a21bd9a-8040-4277-99d4-9de7fcda6d7c/c669f1662f140cbb41fdf0c9cba221a8/dotnet-runtime-3.1.1-win-x86.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.1 (x86)"
+                    Hash="4790D3117F4D4F7AF63113BBECD3BF0E8C940C2A"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.1 (x86)"
+                    Size="23327424"
+                    Version="3.1.1.28408" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -59,7 +57,6 @@
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -76,18 +73,16 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft ASP.NET Core 3.1.1 - Shared Framework"
+                    Hash="65B4D07B6BA51BC7D0D1B82EC904893B8ACF639D"
+                    ProductName="Microsoft ASP.NET Core 3.1.1 - Shared Framework"
+                    Size="7193600"
+                    Version="3.1.1.19615" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -98,7 +93,6 @@
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -115,17 +109,15 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.1 (x86)"
+                    Hash="A368E17FFEE5CEBFDFE981BC329CEFFACF4674CC"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.1 (x86)"
+                    Size="48513144"
+                    Version="3.1.1.28408" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 </Wix>

--- a/src/wixlib/NetCore3.1.2_x64.wxs
+++ b/src/wixlib/NetCore3.1.2_x64.wxs
@@ -11,7 +11,7 @@
 
     <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/326b33d1-6bbd-4149-ba35-c94784700674/c06386c2b09401fa94f9595617899d5d/aspnetcore-runtime-3.1.2-win-x64.exe?>
     <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/3240250e-6fe0-4258-af69-85abef6c00de/e01ee0af6c65d894f4a02bdf6705ec7b/windowsdesktop-runtime-3.1.2-win-x64.exe?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/cfe420d5-084c-4590-b387-f89f3387d4c9/db4c577b995c54dee0530d8230e87145/dotnet-runtime-3.1.2-win-x64.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.2 (x64)"
+                    Hash="6955F4851B42A533683824C65D7423AF22BC6710"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.2 (x64)"
+                    Size="26066088"
+                    Version="3.1.2.28517" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -76,13 +74,13 @@
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
                 <RemotePayload
-                  CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                  CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                  Description="Microsoft ASP.NET Core 3.1.2 - Shared Framework"
-                  Hash="B8EDDD91C0DFD9E47EB7DD7EFED9541340607ADC"
-                  ProductName="Microsoft ASP.NET Core 3.1.2 - Shared Framework"
-                  Size="7812680"
-                  Version="3.1.2.20068"/>
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft ASP.NET Core 3.1.2 - Shared Framework"
+                    Hash="B8EDDD91C0DFD9E47EB7DD7EFED9541340607ADC"
+                    ProductName="Microsoft ASP.NET Core 3.1.2 - Shared Framework"
+                    Size="7812680"
+                    Version="3.1.2.20068"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -112,13 +110,13 @@
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
                 <RemotePayload
-                  CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                  CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                  Description="Microsoft Windows Desktop Runtime - 3.1.2 (x64)"
-                  Hash="C3A76B6C91FB28EFD95422EF82523A73DED322C4"
-                  ProductName="Microsoft Windows Desktop Runtime - 3.1.2 (x64)"
-                  Size="54323576"
-                  Version="3.1.2.28517"/>
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.2 (x64)"
+                    Hash="C3A76B6C91FB28EFD95422EF82523A73DED322C4"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.2 (x64)"
+                    Size="54323576"
+                    Version="3.1.2.28517"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>

--- a/src/wixlib/NetCore3.1.2_x86.wxs
+++ b/src/wixlib/NetCore3.1.2_x86.wxs
@@ -9,9 +9,9 @@
     <?define NetCoreVersion = 3.1.2?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = ?>
-    <?define DesktopNetCoreRedistLink = ?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/2c8e520e-d705-4b11-8854-518546133e27/13354ed8b42d8c2c52f75d7acffd0be4/aspnetcore-runtime-3.1.2-win-x86.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/b824906f-bd6e-4067-86a6-95c61620674d/cfcdab84a01cee94fdaa31271c3d4d47/windowsdesktop-runtime-3.1.2-win-x86.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/dfedf8a5-c3cd-4b69-a5eb-8f9994e810f7/feeead4b3ae3b9e003917797c8356675/dotnet-runtime-3.1.2-win-x86.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.2 (x86)"
+                    Hash="3A53B9646B32B15D20B0B4EDC8EF9787E00EF490"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.2 (x86)"
+                    Size="23298048"
+                    Version="3.1.2.28517" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -59,7 +57,6 @@
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -76,18 +73,16 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft ASP.NET Core 3.1.2 - Shared Framework"
+                    Hash="302D15317C3D2D0B707EAC92D943A624BBDA14D9"
+                    ProductName="Microsoft ASP.NET Core 3.1.2 - Shared Framework"
+                    Size="7128912"
+                    Version="3.1.2.20068" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -98,7 +93,6 @@
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -115,17 +109,15 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.2 (x86)"
+                    Hash="53E9F596F3333EB8576CC237396B5D6A26F98EBE"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.2 (x86)"
+                    Size="48525928"
+                    Version="3.1.2.28517" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 </Wix>

--- a/src/wixlib/NetCore3.1.3_x64.wxs
+++ b/src/wixlib/NetCore3.1.3_x64.wxs
@@ -37,13 +37,14 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                <RemotePayload CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                               CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                               Description="Microsoft .NET Core Runtime - 3.1.3 (x64)"
-                               Hash="AE0F5F1E87D687FDFE9FBE0A3BB1B9573FF9DD56"
-                               ProductName="Microsoft .NET Core Runtime - 3.1.3 (x64)"
-                               Size="26117496"
-                               Version="3.1.3.28628"/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.3 (x64)"
+                    Hash="AE0F5F1E87D687FDFE9FBE0A3BB1B9573FF9DD56"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.3 (x64)"
+                    Size="26117496"
+                    Version="3.1.3.28628"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -72,13 +73,14 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                <RemotePayload CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                               CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                               Description="Microsoft ASP.NET Core 3.1.3 - Shared Framework"
-                               Hash="E6B175E66DE4662CEF161FF3263A97410E993D18"
-                               ProductName="Microsoft ASP.NET Core 3.1.3 - Shared Framework"
-                               Size="7868592"
-                               Version="3.1.3.20163"/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft ASP.NET Core 3.1.3 - Shared Framework"
+                    Hash="E6B175E66DE4662CEF161FF3263A97410E993D18"
+                    ProductName="Microsoft ASP.NET Core 3.1.3 - Shared Framework"
+                    Size="7868592"
+                    Version="3.1.3.20163"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -107,13 +109,14 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                <RemotePayload CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
-                               CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
-                               Description="Microsoft Windows Desktop Runtime - 3.1.3 (x64)"
-                               Hash="9A965A63214627F2C9B3A38E402B561BFD275422"
-                               ProductName="Microsoft Windows Desktop Runtime - 3.1.3 (x64)"
-                               Size="54449000"
-                               Version="3.1.3.28628"/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.3 (x64)"
+                    Hash="9A965A63214627F2C9B3A38E402B561BFD275422"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.3 (x64)"
+                    Size="54449000"
+                    Version="3.1.3.28628"/>
             </ExePackage>
         </PackageGroup>
     </Fragment>

--- a/src/wixlib/NetCore3.1.3_x86.wxs
+++ b/src/wixlib/NetCore3.1.3_x86.wxs
@@ -9,9 +9,9 @@
     <?define NetCoreVersion = 3.1.3?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = ?>
-    <?define DesktopNetCoreRedistLink = ?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/afec5ced-6298-4e54-add1-1d2e02d950f9/3a8064ac78eaf651c0030e8a96d4bd83/aspnetcore-runtime-3.1.3-win-x86.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/7cd5c874-5d11-4e72-81f0-4a005d956708/0eb310169770c893407169fc3abaac4f/windowsdesktop-runtime-3.1.3-win-x86.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/9afebfd7-7719-4612-b15b-79b67b725b42/b93c5514f58eed2e66fc30d0e88aafcb/dotnet-runtime-3.1.3-win-x86.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.2 (x86)"
+                    Hash="3A53B9646B32B15D20B0B4EDC8EF9787E00EF490"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.2 (x86)"
+                    Size="23298048"
+                    Version="3.1.2.28517" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -59,7 +57,6 @@
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -76,18 +73,16 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft ASP.NET Core 3.1.3 - Shared Framework"
+                    Hash="42F8DF6AAC1299E05A04B4D2DB3E10D0D1A8E942"
+                    ProductName="Microsoft ASP.NET Core 3.1.3 - Shared Framework"
+                    Size="7157720"
+                    Version="3.1.3.20163" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -98,7 +93,6 @@
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -115,17 +109,15 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.2 (x86)"
+                    Hash="53E9F596F3333EB8576CC237396B5D6A26F98EBE"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.2 (x86)"
+                    Size="48525928"
+                    Version="3.1.2.28517" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 </Wix>

--- a/src/wixlib/NetCore3.1.4_x64.wxs
+++ b/src/wixlib/NetCore3.1.4_x64.wxs
@@ -9,9 +9,9 @@
     <?define NetCoreVersion = 3.1.4?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = ?>
-    <?define DesktopNetCoreRedistLink = ?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/f9598bd0-060a-46c1-b5ce-65f1663f6204/afb4dd9e1377f63a5c124d60fb119764/aspnetcore-runtime-3.1.4-win-x64.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/d8cf1fe3-21c2-4baf-988f-f0152996135e/0c00b94713ee93e7ad5b4f82e2b86607/windowsdesktop-runtime-3.1.4-win-x64.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/93d4ac87-6db0-4ddd-9bef-8050067b5e5d/605b178040bdd75b63d021d9387219ea/dotnet-runtime-3.1.4-win-x64.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="3756E9BBF4461DCD0AA68E0D1FCFFA9CEA47AC18"
+                    CertificateThumbprint="2485A7AFA98E178CB8F30C9838346B514AEA4769"
+                    Description="Microsoft .NET Core Runtime - 3.1.4 (x64)"
+                    Hash="F60C08D1FB8B6D5A8AC5D008928B673AAC5D0278"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.4 (x64)"
+                    Size="26159064"
+                    Version="3.1.4.28821" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -59,7 +57,6 @@
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -76,18 +73,16 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="3756E9BBF4461DCD0AA68E0D1FCFFA9CEA47AC18"
+                    CertificateThumbprint="2485A7AFA98E178CB8F30C9838346B514AEA4769"
+                    Description="Microsoft ASP.NET Core 3.1.4 - Shared Framework"
+                    Hash="5CF68BFFE3377DCBE03986380098D93AB876FF13"
+                    ProductName="Microsoft ASP.NET Core 3.1.4 - Shared Framework"
+                    Size="7829704"
+                    Version="3.1.4.20222" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -98,7 +93,6 @@
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -115,17 +109,15 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.4 (x64)"
+                    Hash="78BA9B86F57379D8FE20C7C06038B79C0B7051F6"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.4 (x64)"
+                    Size="54480864"
+                    Version="3.1.4.28821" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 </Wix>

--- a/src/wixlib/NetCore3.1.4_x86.wxs
+++ b/src/wixlib/NetCore3.1.4_x86.wxs
@@ -9,9 +9,9 @@
     <?define NetCoreVersion = 3.1.4?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = ?>
-    <?define DesktopNetCoreRedistLink = ?>
-    <?define DotNetCoreRedistLink = ?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/adef45e2-4f8f-4880-b1f7-08c63edd640f/cf3e68f27ae8cb1e820af6ecafc24eee/aspnetcore-runtime-3.1.4-win-x86.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/2d4b7600-5f32-4a1f-abd5-47cdb2d1362b/7b8b7635e3bb63f6b2cc9a1c624b5325/windowsdesktop-runtime-3.1.4-win-x86.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/03b8b6cb-c80c-43ea-9136-1156e839bb52/31c13e5a5b028a3c721a50df8f02caf0/dotnet-runtime-3.1.4-win-x86.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.DotNetCoreId)" />
@@ -21,7 +21,6 @@
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -38,17 +37,16 @@
                 DownloadUrl="$(var.DotNetCoreRedistLink)"
                 LogPathVariable="$(var.DotNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
-                <RemotePayload CertificatePublicKey=""
-                               CertificateThumbprint=""
-                               Description=""
-                               Hash=""
-                               ProductName=""
-                               Size=""
-                               Version=""/>
+                <RemotePayload
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft .NET Core Runtime - 3.1.4 (x86)"
+                    Hash="4FA35E3F31BCFCC6B65D0CB13E21EE0FC56D1C6B"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.4 (x86)"
+                    Size="23345544"
+                    Version="3.1.4.28821" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -59,7 +57,6 @@
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -76,18 +73,16 @@
                 DownloadUrl="$(var.AspNetCoreRedistLink)"
                 LogPathVariable="$(var.AspNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="3756E9BBF4461DCD0AA68E0D1FCFFA9CEA47AC18"
+                    CertificateThumbprint="2485A7AFA98E178CB8F30C9838346B514AEA4769"
+                    Description="Microsoft ASP.NET Core 3.1.4 - Shared Framework"
+                    Hash="2272BF19490DA6519FC2735A2C8815F8944D3388"
+                    ProductName="Microsoft ASP.NET Core 3.1.4 - Shared Framework"
+                    Size="7171864"
+                    Version="3.1.4.20222" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 
     <Fragment>
@@ -98,7 +93,6 @@
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory" Value="redist\" Overridable="yes" />
         <WixVariable Id="DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairCommand" Value="" Overridable="yes" />
 
-        <!--
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
                 Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
@@ -115,17 +109,15 @@
                 DownloadUrl="$(var.DesktopNetCoreRedistLink)"
                 LogPathVariable="$(var.DesktopNetCoreRedistLog)"
                 Compressed="no">
-                TODO: Get RemotePayload info
                 <RemotePayload
-                  CertificatePublicKey=""
-                  CertificateThumbprint=""
-                  Description=""
-                  Hash=""
-                  ProductName=""
-                  Size=""
-                  Version="" />
+                    CertificatePublicKey="6ADD0C9D1AC70DA3668644B1C78884E82E3F3457"
+                    CertificateThumbprint="711AF71DC4C4952C8ED65BB4BA06826ED3922A32"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.4 (x86)"
+                    Hash="331BF47FD6E95174D17B63938C022A48E02CB8BF"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.4 (x86)"
+                    Size="48703936"
+                    Version="3.1.4.28821" />
             </ExePackage>
         </PackageGroup>
-        -->
     </Fragment>
 </Wix>


### PR DESCRIPTION
Several of the .NET Core package definitions are incomplete (missing redist links and remote payload information). This PR adds all of the missing information and makes the payload styling consistent.