### PR TITLE
4183 - ExePackagePayload and other changes

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "WixToolset.Sdk": "4.0.0-build-0189"
+    "WixToolset.Sdk": "4.0.0-build-0193"
   }
 }

--- a/src/ca/netfxca.vcxproj
+++ b/src/ca/netfxca.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\WixToolset.DUtil.4.0.62\build\WixToolset.DUtil.props" Condition="Exists('..\..\packages\WixToolset.DUtil.4.0.62\build\WixToolset.DUtil.props')" />
+  <Import Project="..\..\packages\WixToolset.DUtil.4.0.64\build\WixToolset.DUtil.props" Condition="Exists('..\..\packages\WixToolset.DUtil.4.0.64\build\WixToolset.DUtil.props')" />
   <Import Project="..\..\packages\WixToolset.WcaUtil.4.0.18\build\WixToolset.WcaUtil.props" Condition="Exists('..\..\packages\WixToolset.WcaUtil.4.0.18\build\WixToolset.WcaUtil.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -62,7 +62,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\WixToolset.DUtil.4.0.62\build\WixToolset.DUtil.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WixToolset.DUtil.4.0.62\build\WixToolset.DUtil.props'))" />
+    <Error Condition="!Exists('..\..\packages\WixToolset.DUtil.4.0.64\build\WixToolset.DUtil.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WixToolset.DUtil.4.0.64\build\WixToolset.DUtil.props'))" />
     <Error Condition="!Exists('..\..\packages\WixToolset.WcaUtil.4.0.18\build\WixToolset.WcaUtil.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\WixToolset.WcaUtil.4.0.18\build\WixToolset.WcaUtil.props'))" />
   </Target>
 </Project>

--- a/src/ca/packages.config
+++ b/src/ca/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WixToolset.DUtil" version="4.0.62" targetFramework="native" />
+  <package id="WixToolset.DUtil" version="4.0.64" targetFramework="native" />
   <package id="WixToolset.WcaUtil" version="4.0.18" targetFramework="native" />
 </packages>

--- a/src/wixlib/NetCore3.1.12_x64.wxs
+++ b/src/wixlib/NetCore3.1.12_x64.wxs
@@ -4,14 +4,14 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
-    <?define NetCorePlatform = x86?>
-    <?define NetCoreIdVersion = 318?>
-    <?define NetCoreVersion = 3.1.8?>
+    <?define NetCorePlatform = x64?>
+    <?define NetCoreIdVersion = 3112?>
+    <?define NetCoreVersion = 3.1.12?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = https://go.microsoft.com/fwlink/?linkid=2143951?>
-    <?define DesktopNetCoreRedistLink = https://go.microsoft.com/fwlink/?linkid=2143791?>
-    <?define DotNetCoreRedistLink = https://go.microsoft.com/fwlink/?linkid=2144014?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/20cf277c-2ccf-449f-a0b8-925ba0c175e7/aa50b052ceb8a8d36a5b4f9b8d0bd91c/aspnetcore-runtime-3.1.12-win-x64.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/076a47e9-c65b-4b78-95a7-93eb988891a4/3574764590cfa650e0aa87c44d3fe384/windowsdesktop-runtime-3.1.12-win-x64.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/2fdc3009-cf5c-4cf6-8f3b-a61e83200cbb/2c71ee04b48103a7464f4e28a8bf339b/dotnet-runtime-3.1.12-win-x64.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.AspNetCoreId)" />
@@ -23,7 +23,6 @@
 
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
-                Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
                 InstallArguments="$(var.AspNetCoreRedistInstallArguments)"
                 RepairArguments="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairArguments)"
                 UninstallArguments="$(var.AspNetCoreRedistUninstallArguments)"
@@ -34,15 +33,15 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="burn"
-                DownloadUrl="$(var.AspNetCoreRedistLink)"
-                LogPathVariable="$(var.AspNetCoreRedistLog)"
-                Compressed="no">
-                <RemotePayload
-                    Description="Microsoft ASP.NET Core 3.1.8 - Shared Framework"
-                    Hash="39CAC2A47CB57594C6FC2ED693DF1A02064CBC8D"
-                    ProductName="Microsoft ASP.NET Core 3.1.8 - Shared Framework"
-                    Size="7160128"
-                    Version="3.1.8.20421" />
+                LogPathVariable="$(var.AspNetCoreRedistLog)">
+                <ExePackagePayload
+                    Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
+                    DownloadUrl="$(var.AspNetCoreRedistLink)"
+                    Description="Microsoft ASP.NET Core 3.1.12 - Shared Framework"
+                    Hash="5CE9839CAE90FB2936033431F2905E97C7DC080DC50108D58714939CCCC6A265694B8259A3BF742A68BF04D9CFFB0602B0306DD401C4CE644BDB96C7D1168E59"
+                    ProductName="Microsoft ASP.NET Core 3.1.12 - Shared Framework"
+                    Size="7841808"
+                    Version="3.1.12.21070" />
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -57,7 +56,6 @@
 
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
-                Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
                 InstallArguments="$(var.DesktopNetCoreRedistInstallArguments)"
                 RepairArguments="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairArguments)"
                 UninstallArguments="$(var.DesktopNetCoreRedistUninstallArguments)"
@@ -68,15 +66,15 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="burn"
-                DownloadUrl="$(var.DesktopNetCoreRedistLink)"
-                LogPathVariable="$(var.DesktopNetCoreRedistLog)"
-                Compressed="no">
-                <RemotePayload
-                    Description="Microsoft Windows Desktop Runtime - 3.1.8 (x86)"
-                    Hash="6105823D7417C265929DF2978A7214E7394E404F"
-                    ProductName="Microsoft Windows Desktop Runtime - 3.1.8 (x86)"
-                    Size="48377976"
-                    Version="3.1.8.29220" />
+                LogPathVariable="$(var.DesktopNetCoreRedistLog)">
+                <ExePackagePayload
+                    Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
+                    DownloadUrl="$(var.DesktopNetCoreRedistLink)"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.12 (x64)"
+                    Hash="CD69B8722B2FF175FADD6774AB6A97F89292FC57A15CEC95218E79FFF1E26F46A7EFFFB15CE0F6D22B83B991F7083BB5C04F5158F87D298EA0F204933F8ECD27"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.12 (x64)"
+                    Size="54284816"
+                    Version="3.1.12.29719" />
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -91,7 +89,6 @@
 
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
-                Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
                 InstallArguments="$(var.DotNetCoreRedistInstallArguments)"
                 RepairArguments="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairArguments)"
                 UninstallArguments="$(var.DotNetCoreRedistUninstallArguments)"
@@ -102,15 +99,15 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="burn"
-                DownloadUrl="$(var.DotNetCoreRedistLink)"
-                LogPathVariable="$(var.DotNetCoreRedistLog)"
-                Compressed="no">
-                <RemotePayload
-                    Description="Microsoft .NET Core Runtime - 3.1.8 (x86)"
-                    Hash="E3B05751BA0E48D81EF3EB60DABFC6388BAA5E91"
-                    ProductName="Microsoft .NET Core Runtime - 3.1.8 (x86)"
-                    Size="23183576"
-                    Version="3.1.8.29220" />
+                LogPathVariable="$(var.DotNetCoreRedistLog)">
+                <ExePackagePayload
+                    Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
+                    DownloadUrl="$(var.DotNetCoreRedistLink)"
+                    Description="Microsoft .NET Core Runtime - 3.1.12 (x64)"
+                    Hash="9B3F882AE5DFDC8B50D3CEC4F3292292D658B2FECB84B3F73426FB3C16E6FC6B8E7118EF559CFAE25ED7A2C175FA4D89E18986CA3C05D15F706524FBB667F702"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.12 (x64)"
+                    Size="26090616"
+                    Version="3.1.12.29719" />
             </ExePackage>
         </PackageGroup>
     </Fragment>

--- a/src/wixlib/NetCore3.1.12_x86.wxs
+++ b/src/wixlib/NetCore3.1.12_x86.wxs
@@ -4,14 +4,14 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
-    <?define NetCorePlatform = x64?>
-    <?define NetCoreIdVersion = 318?>
-    <?define NetCoreVersion = 3.1.8?>
+    <?define NetCorePlatform = x86?>
+    <?define NetCoreIdVersion = 3112?>
+    <?define NetCoreVersion = 3.1.12?>
     <?include NetCore3_Platform.wxi?>
 
-    <?define AspNetCoreRedistLink = https://go.microsoft.com/fwlink/?linkid=2143792?>
-    <?define DesktopNetCoreRedistLink = https://go.microsoft.com/fwlink/?linkid=2143950?>
-    <?define DotNetCoreRedistLink = https://go.microsoft.com/fwlink/?linkid=2143846?>
+    <?define AspNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/55d6ff56-2725-4657-bffd-fdf35d6816fd/7431d1d3533f0b1ac97df734c45c33f2/aspnetcore-runtime-3.1.12-win-x86.exe?>
+    <?define DesktopNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/5d89a010-88bf-4e4e-ac12-a07258ddbf5f/1ff5dfe312c5bd9760f3b500b1b37597/windowsdesktop-runtime-3.1.12-win-x86.exe?>
+    <?define DotNetCoreRedistLink = https://download.visualstudio.microsoft.com/download/pr/cbdd1603-7fa9-4957-8869-94e24963ba6c/ca0b7d1be494882d5a7433accfa3c94c/dotnet-runtime-3.1.12-win-x86.exe?>
 
     <Fragment>
         <util:DirectorySearchRef Id="$(var.AspNetCoreId)" />
@@ -23,7 +23,6 @@
 
         <PackageGroup Id="$(var.AspNetCoreRedistId)">
             <ExePackage
-                Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
                 InstallArguments="$(var.AspNetCoreRedistInstallArguments)"
                 RepairArguments="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairArguments)"
                 UninstallArguments="$(var.AspNetCoreRedistUninstallArguments)"
@@ -34,15 +33,15 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="burn"
-                DownloadUrl="$(var.AspNetCoreRedistLink)"
-                LogPathVariable="$(var.AspNetCoreRedistLog)"
-                Compressed="no">
-                <RemotePayload
-                    Description="Microsoft ASP.NET Core 3.1.8 - Shared Framework"
-                    Hash="61DC9EAA0C8968E48E13C5913ED202A2F8F94DBA"
-                    ProductName="Microsoft ASP.NET Core 3.1.8 - Shared Framework"
-                    Size="7841880"
-                    Version="3.1.8.20421" />
+                LogPathVariable="$(var.AspNetCoreRedistLog)">
+                <ExePackagePayload
+                    Name="!(wix.AspNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)aspnetcore-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
+                    DownloadUrl="$(var.AspNetCoreRedistLink)"
+                    Description="Microsoft ASP.NET Core 3.1.12 - Shared Framework"
+                    Hash="03EE5F6D3B2AF8FFE2A5154BB05E50938E2D36E98D996D9E67A3C349DD0C8B3051D5A9628F48C51E006CEA0B1F4484B4BE51920FE5CA841060B0D2C6A12FD5D2"
+                    ProductName="Microsoft ASP.NET Core 3.1.12 - Shared Framework"
+                    Size="7841808"
+                    Version="3.1.12.21070" />
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -57,7 +56,6 @@
 
         <PackageGroup Id="$(var.DesktopNetCoreRedistId)">
             <ExePackage
-                Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
                 InstallArguments="$(var.DesktopNetCoreRedistInstallArguments)"
                 RepairArguments="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairArguments)"
                 UninstallArguments="$(var.DesktopNetCoreRedistUninstallArguments)"
@@ -68,15 +66,15 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="burn"
-                DownloadUrl="$(var.DesktopNetCoreRedistLink)"
-                LogPathVariable="$(var.DesktopNetCoreRedistLog)"
-                Compressed="no">
-                <RemotePayload
-                    Description="Microsoft Windows Desktop Runtime - 3.1.8 (x64)"
-                    Hash="6DEE30E0C636B13650E7CE1D13E8CCC99CB2A7AC"
-                    ProductName="Microsoft Windows Desktop Runtime - 3.1.8 (x64)"
-                    Size="54253328"
-                    Version="3.1.8.29220" />
+                LogPathVariable="$(var.DesktopNetCoreRedistLog)">
+                <ExePackagePayload
+                    Name="!(wix.DesktopNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)windowsdesktop-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
+                    DownloadUrl="$(var.DesktopNetCoreRedistLink)"
+                    Description="Microsoft Windows Desktop Runtime - 3.1.12 (x86)"
+                    Hash="C211A7F29D9B6FEEFCF0379B153FFBFB815157D3D494CFD7D0D84D619701EEA284BF12502094BCFF2BB2968213190454E7CE0E865FD623E78C2FCDAEBEF963DA"
+                    ProductName="Microsoft Windows Desktop Runtime - 3.1.12 (x86)"
+                    Size="48590696"
+                    Version="3.1.12.29719" />
             </ExePackage>
         </PackageGroup>
     </Fragment>
@@ -91,7 +89,6 @@
 
         <PackageGroup Id="$(var.DotNetCoreRedistId)">
             <ExePackage
-                Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
                 InstallArguments="$(var.DotNetCoreRedistInstallArguments)"
                 RepairArguments="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)RepairArguments)"
                 UninstallArguments="$(var.DotNetCoreRedistUninstallArguments)"
@@ -102,15 +99,15 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="burn"
-                DownloadUrl="$(var.DotNetCoreRedistLink)"
-                LogPathVariable="$(var.DotNetCoreRedistLog)"
-                Compressed="no">
-                <RemotePayload
-                    Description="Microsoft .NET Core Runtime - 3.1.8 (x64)"
-                    Hash="C51D55F163788404ECADE0BF32B3D7796EEAE449"
-                    ProductName="Microsoft .NET Core Runtime - 3.1.8 (x64)"
-                    Size="26089480"
-                    Version="3.1.8.29220" />
+                LogPathVariable="$(var.DotNetCoreRedistLog)">
+                <ExePackagePayload
+                    Name="!(wix.DotNetCoreRuntime$(var.NetCoreIdVersion)Redist$(var.NetCorePlatform)PackageDirectory)dotnet-runtime-$(var.NetCoreVersion)-win-$(var.NetCorePlatform).exe"
+                    DownloadUrl="$(var.DotNetCoreRedistLink)"
+                    Description="Microsoft .NET Core Runtime - 3.1.12 (x86)"
+                    Hash="BA18F9028B19630D91017BEACCD8D79388125C228A83B5A62306108F3BB283617A7ED9B98785BC73192EC00E5D186DA767E940DCAB388699FAF274E437D0C16F"
+                    ProductName="Microsoft .NET Core Runtime - 3.1.12 (x86)"
+                    Size="23392184"
+                    Version="3.1.12.29719" />
             </ExePackage>
         </PackageGroup>
     </Fragment>

--- a/src/wixlib/NetCore3.1_x64.wxs
+++ b/src/wixlib/NetCore3.1_x64.wxs
@@ -6,19 +6,19 @@
 
     <Fragment>
         <PackageGroup Id="AspNetCoreRuntime31Redist_x64">
-            <PackageGroupRef Id="AspNetCoreRuntime318Redist_x64" />
+            <PackageGroupRef Id="AspNetCoreRuntime3112Redist_x64" />
         </PackageGroup>
     </Fragment>
 
     <Fragment>
         <PackageGroup Id="DesktopNetCoreRuntime31Redist_x64">
-            <PackageGroupRef Id="DesktopNetCoreRuntime318Redist_x64" />
+            <PackageGroupRef Id="DesktopNetCoreRuntime3112Redist_x64" />
         </PackageGroup>
     </Fragment>
 
     <Fragment>
         <PackageGroup Id="DotNetCoreRuntime31Redist_x64">
-            <PackageGroupRef Id="DotNetCoreRuntime318Redist_x64" />
+            <PackageGroupRef Id="DotNetCoreRuntime3112Redist_x64" />
         </PackageGroup>
     </Fragment>
 </Wix>

--- a/src/wixlib/NetCore3.1_x86.wxs
+++ b/src/wixlib/NetCore3.1_x86.wxs
@@ -6,19 +6,19 @@
 
     <Fragment>
         <PackageGroup Id="AspNetCoreRuntime31Redist_x86">
-            <PackageGroupRef Id="AspNetCoreRuntime318Redist_x86" />
+            <PackageGroupRef Id="AspNetCoreRuntime3112Redist_x86" />
         </PackageGroup>
     </Fragment>
 
     <Fragment>
         <PackageGroup Id="DesktopNetCoreRuntime31Redist_x86">
-            <PackageGroupRef Id="DesktopNetCoreRuntime318Redist_x86" />
+            <PackageGroupRef Id="DesktopNetCoreRuntime3112Redist_x86" />
         </PackageGroup>
     </Fragment>
 
     <Fragment>
         <PackageGroup Id="DotNetCoreRuntime31Redist_x86">
-            <PackageGroupRef Id="DotNetCoreRuntime318Redist_x86" />
+            <PackageGroupRef Id="DotNetCoreRuntime3112Redist_x86" />
         </PackageGroup>
     </Fragment>
 </Wix>

--- a/src/wixlib/NetFx4.5.wxs
+++ b/src/wixlib/NetFx4.5.wxs
@@ -3,7 +3,6 @@
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <!--
@@ -35,88 +34,6 @@
         Key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"
         Value="Release"
         Result="value" />
-  </Fragment>
-  
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK45" />
-
-    <WixVariable Id="NetFx45WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx45MinRelease)" Overridable="yes" />
-    <WixVariable Id="NetFx45WebInstallCondition" Value="" Overridable="yes" />
-    <WixVariable Id="NetFx45WebPackageDirectory" Value="redist\" Overridable="yes" />
-
-    <PackageGroup Id="$(var.NetFx45WebId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx45FullWebLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx45FullWebLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx45FullWebLog].html&quot;"
-          PerMachine="yes"
-          DetectCondition="!(wix.NetFx45WebDetectCondition)"
-          InstallCondition="!(wix.NetFx45WebInstallCondition)"
-          Id="$(var.NetFx45WebId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx45WebLink)"
-          LogPathVariable="NetFx45FullWebLog"
-          Compressed="no"
-          Name="!(wix.NetFx45WebPackageDirectory)dotNetFx45_Full_setup.exe">
-        <RemotePayload
-            Size="1005568"
-            Version="4.5.50709.17929"
-            ProductName="Microsoft .NET Framework 4.5"
-            Description="Microsoft .NET Framework 4.5 Setup"
-            Hash="F6BA6F03C65C3996A258F58324A917463B2D6FF4"/>
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx45WebId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx45WebId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx45WebId)" LicenseUrl="$(var.NetFx45EulaLink)" />
-  </Fragment>
-
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK45" />
-
-    <WixVariable Id="NetFx45RedistDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx45MinRelease)" Overridable="yes" />
-    <WixVariable Id="NetFx45RedistInstallCondition" Value="" Overridable="yes" />
-    <WixVariable Id="NetFx45RedistPackageDirectory" Value="redist\" Overridable="yes" />
-
-    <PackageGroup Id="$(var.NetFx45RedistId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx45FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx45FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx45FullLog].html&quot;"
-          PerMachine="yes"
-          DetectCondition="!(wix.NetFx45RedistDetectCondition)"
-          InstallCondition="!(wix.NetFx45RedistInstallCondition)"
-          Id="$(var.NetFx45RedistId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx45RedistLink)"
-          LogPathVariable="NetFx45FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx45RedistPackageDirectory)dotNetFx45_Full_x86_x64.exe">
-        <RemotePayload
-            Size="50352408" 
-            Version="4.5.50709.17929"
-            ProductName="Microsoft .NET Framework 4.5"
-            Description="Microsoft .NET Framework 4.5 Setup"
-            Hash="B2FF712CA0947040CA0B8E9BD7436A3C3524BB5D"/>
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx45RedistId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx45RedistId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx45RedistId)" LicenseUrl="$(var.NetFx45EulaLink)" />
   </Fragment>
 
   <!-- set to Release number of the .NET Framework 4.5 if installed (not set otherwise) -->

--- a/src/wixlib/NetFx4.wxs
+++ b/src/wixlib/NetFx4.wxs
@@ -3,7 +3,6 @@
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <!--
@@ -41,76 +40,6 @@
   </Fragment>
 
   <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK40" />
-
-    <PackageGroup Id="$(var.NetFx40WebId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          PerMachine="yes"
-          DetectCondition="NETFRAMEWORK40"
-          Id="$(var.NetFx40WebId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx40WebLink)"
-          Compressed="no"
-          Name="redist\dotNetFx40_Full_setup.exe">
-        <RemotePayload
-            Size="889416"
-            Version="4.0.30319.1"
-            ProductName="Microsoft .NET Framework 4"
-            Description="Microsoft .NET Framework 4 Setup"
-            Hash="06BECADB92A5FCCA2529C0B93687C2A0C6D0D610"/>
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx40WebId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx40WebId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx40WebId)" LicenseUrl="$(var.NetFx40EulaLink)" />
-  </Fragment>
-
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK40" />
-
-    <PackageGroup Id="$(var.NetFx40RedistId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          PerMachine="yes"
-          DetectCondition="NETFRAMEWORK40"
-          Id="$(var.NetFx40RedistId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx40RedistLink)"
-          Compressed="no"
-          Name="redist\dotNetFx40_Full_x86_x64.exe">
-        <RemotePayload
-            Size="50449456"
-            Version="4.0.30319.1"
-            ProductName="Microsoft .NET Framework 4"
-            Description="Microsoft .NET Framework 4 Setup"
-            Hash="58DA3D74DB353AAD03588CBB5CEA8234166D8B99"/>
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx40RedistId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx40RedistId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx40RedistId)" LicenseUrl="$(var.NetFx40EulaLink)" />
-  </Fragment>
-
-  <Fragment>
     <util:RegistrySearch
         Id="NETFRAMEWORK40CLIENT"
         Variable="NETFRAMEWORK40CLIENT"
@@ -118,76 +47,6 @@
         Key="SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client"
         Value="Install"
         Result="value" />
-  </Fragment>
-
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK40CLIENT" />
-
-    <PackageGroup Id="$(var.NetFx40ClientWebId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          PerMachine="yes"
-          DetectCondition="NETFRAMEWORK40CLIENT"
-          Id="$(var.NetFx40ClientWebId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx40ClientWebLink)"
-          Compressed="no"
-          Name="redist\dotNetFx40_Client_setup.exe">
-        <RemotePayload
-            Size="887896"
-            Version="4.0.30319.1"
-            ProductName="Microsoft .NET Framework 4 Client Profile"
-            Description="Microsoft .NET Framework 4 Client Profile Setup"
-            Hash="E15AD80FC74277EF2048312E9A71AF56B2EBA622"/>
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx40ClientWebId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx40ClientWebId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx40ClientWebId)" LicenseUrl="$(var.NetFx40EulaLink)" />
-  </Fragment>
-
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK40CLIENT" />
-
-    <PackageGroup Id="$(var.NetFx40ClientRedistId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot;"
-          PerMachine="yes"
-          DetectCondition="NETFRAMEWORK40CLIENT"
-          Id="$(var.NetFx40ClientRedistId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx40ClientRedistLink)"
-          Compressed="no"
-          Name="redist\dotNetFx40_Client_x86_x64.exe">
-        <RemotePayload
-            Size="43000680"
-            Version="4.0.30319.1"
-            ProductName="Microsoft .NET Framework 4 Client Profile"
-            Description="Microsoft .NET Framework 4 Client Profile Setup"
-            Hash="4CD67F609F89D617D2B206341B8C211E1B88B287"/>
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx40ClientRedistId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx40ClientRedistId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx40ClientRedistId)" LicenseUrl="$(var.NetFx40EulaLink)" />
   </Fragment>
 
   <!-- set to #1 if the .NET Framework 4.0 client is installed (not set otherwise) -->

--- a/src/wixlib/NetFx451.wxs
+++ b/src/wixlib/NetFx451.wxs
@@ -3,7 +3,6 @@
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <!--
@@ -25,87 +24,5 @@
     <PropertyRef Id="WIXNETFX4RELEASEINSTALLED" />
     <Property Id="WIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED" Secure="yes" />
     <SetProperty Id="WIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED" Value="1" After="AppSearch" Condition="WIXNETFX4RELEASEINSTALLED &gt;= &quot;#$(var.NetFx451MinRelease)&quot;" />
-  </Fragment>
-
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK45" />
-
-    <WixVariable Id="NetFx451WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx451MinRelease)" Overridable="yes" />
-    <WixVariable Id="NetFx451WebInstallCondition" Value="" Overridable="yes" />
-    <WixVariable Id="NetFx451WebPackageDirectory" Value="redist\" Overridable="yes" />
-
-    <PackageGroup Id="$(var.NetFx451WebId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx451FullWebLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx451FullWebLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx451FullWebLog].html&quot;"
-          PerMachine="yes"
-          DetectCondition="!(wix.NetFx451WebDetectCondition)"
-          InstallCondition="!(wix.NetFx451WebInstallCondition)"
-          Id="$(var.NetFx451WebId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx451WebLink)"
-          LogPathVariable="NetFx451FullWebLog"
-          Compressed="no"
-          Name="!(wix.NetFx451WebPackageDirectory)NDP451-KB2859818-Web.exe">
-        <RemotePayload
-            Size="1021432"
-            Version="4.5.50938.18408"
-            ProductName="Microsoft .NET Framework 4.5.1"
-            Description="Microsoft .NET Framework 4.5.1 Setup"
-            Hash="4CBEA1E408DB5B423E130931B9478972E6798431" />
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx451WebId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx451WebId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx451WebId)" LicenseUrl="$(var.NetFx451EulaLink)" />
-  </Fragment>
-
-  <Fragment>
-    <util:RegistrySearchRef Id="NETFRAMEWORK45" />
-
-    <WixVariable Id="NetFx451RedistDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx451MinRelease)" Overridable="yes" />
-    <WixVariable Id="NetFx451RedistInstallCondition" Value="" Overridable="yes" />
-    <WixVariable Id="NetFx451RedistPackageDirectory" Value="redist\" Overridable="yes" />
-
-    <PackageGroup Id="$(var.NetFx451RedistId)">
-      <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx451FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx451FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx451FullLog].html&quot;"
-          PerMachine="yes"
-          DetectCondition="!(wix.NetFx451RedistDetectCondition)"
-          InstallCondition="!(wix.NetFx451RedistInstallCondition)"
-          Id="$(var.NetFx451RedistId)"
-          Vital="yes"
-          Permanent="yes"
-          Protocol="netfx4"
-          DownloadUrl="$(var.NetFx451RedistLink)"
-          LogPathVariable="NetFx451FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx451RedistPackageDirectory)NDP451-KB2858728-x86-x64-AllOS-ENU.exe">
-        <RemotePayload
-            Size="70087104"
-            Version="4.5.50938.18408"
-            ProductName="Microsoft .NET Framework 4.5.1"
-            Description="Microsoft .NET Framework 4.5.1 Setup"
-            Hash="5934DD101414BBC0B7F1EE2780D2FC8B9BEC5C4D" />
-      </ExePackage>
-    </PackageGroup>
-  </Fragment>
-
-  <Fragment>
-    <PackageGroup Id="$(var.NetFx451RedistId)AsPrereq">
-      <PackageGroupRef Id="$(var.NetFx451RedistId)" />
-    </PackageGroup>
-
-    <bal:ManagedBootstrapperApplicationPrereqInformation PackageId="$(var.NetFx451RedistId)" LicenseUrl="$(var.NetFx451EulaLink)" />
   </Fragment>
 </Wix>

--- a/src/wixlib/NetFx452.wxs
+++ b/src/wixlib/NetFx452.wxs
@@ -14,9 +14,9 @@
     -->
 
   <?define NetFx452MinRelease = 379893 ?>
-  <?define NetFx452WebLink = http://go.microsoft.com/fwlink/?LinkId=397707 ?>
-  <?define NetFx452RedistLink = http://go.microsoft.com/fwlink/?LinkId=397708 ?>
-  <?define NetFx452EulaLink = http://wixtoolset.org/licenses/netfx452 ?>
+  <?define NetFx452WebLink = https://go.microsoft.com/fwlink/?LinkId=397707 ?>
+  <?define NetFx452RedistLink = https://go.microsoft.com/fwlink/?LinkId=397708 ?>
+  <?define NetFx452EulaLink = https://wixtoolset.org/licenses/netfx452 ?>
   <?define NetFx452WebId = NetFx452Web ?>
   <?define NetFx452RedistId = NetFx452Redist ?>
 
@@ -35,9 +35,8 @@
 
     <PackageGroup Id="$(var.NetFx452WebId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx452FullWebLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx452FullWebLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx452FullWebLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx452FullWebLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx452FullWebLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx452WebDetectCondition)"
           InstallCondition="!(wix.NetFx452WebInstallCondition)"
@@ -45,13 +44,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx452FullWebLog">
+        <ExePackagePayload 
+          Name="!(wix.NetFx452WebPackageDirectory)NDP452-KB2901954-Web.exe"
           DownloadUrl="$(var.NetFx452WebLink)"
-          LogPathVariable="NetFx452FullWebLog"
-          Compressed="no"
-          Name="!(wix.NetFx452WebPackageDirectory)NDP452-KB2901954-Web.exe">
-        <RemotePayload 
           Description="Microsoft .NET Framework 4.5.2 Setup"
-          Hash="5B71B20A455F6EEAB79DD1EDCAB0BA66AD0D2208"
+          Hash="90A3A5A57EA8A6508EEE0D129303C7CB012AABF651DD9A6BEFC20DA3BBDB09FC47FD087645051D3D45BFF909DFC6E6039C22C4816FBC793A847E81701248639E"
           ProductName="Microsoft .NET Framework 4.5.2"
           Size="1118920"
           Version="4.5.51209.34209" />
@@ -76,9 +74,8 @@
 
     <PackageGroup Id="$(var.NetFx452RedistId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx452FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx452FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx452FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx452FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx452FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx452RedistDetectCondition)"
           InstallCondition="!(wix.NetFx452RedistInstallCondition)"
@@ -86,13 +83,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx452FullLog">
+        <ExePackagePayload 
+          Name="!(wix.NetFx452RedistPackageDirectory)NDP452-KB2901907-x86-x64-AllOS-ENU.exe"
           DownloadUrl="$(var.NetFx452RedistLink)"
-          LogPathVariable="NetFx452FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx452RedistPackageDirectory)NDP452-KB2901907-x86-x64-AllOS-ENU.exe">
-        <RemotePayload 
           Description="Microsoft .NET Framework 4.5.2 Setup"
-          Hash="89F86F9522DC7A8A965FACCE839ABB790A285A63"
+          Hash="033D457229C4FE6EEA7B1E42A3A39DD4CF6A054C5E996CE036942DD2FE9623FD3A0634BE5DCB88506C1C61BF9FF6076F27B4ECEC38F8CF85603AF018111E584D"
           ProductName="Microsoft .NET Framework 4.5.2"
           Size="69999448"
           Version="4.5.51209.34209" />

--- a/src/wixlib/NetFx46.wxs
+++ b/src/wixlib/NetFx46.wxs
@@ -15,9 +15,9 @@
     -->
 
   <?define NetFx46MinRelease = 393295 ?>
-  <?define NetFx46WebLink = http://go.microsoft.com/fwlink/?LinkId=560371 ?>
-  <?define NetFx46RedistLink = http://go.microsoft.com/fwlink/?LinkId=560369 ?>
-  <?define NetFx46EulaLink = http://go.microsoft.com/fwlink/?LinkID=558772 ?>
+  <?define NetFx46WebLink = https://go.microsoft.com/fwlink/?LinkId=560371 ?>
+  <?define NetFx46RedistLink = https://go.microsoft.com/fwlink/?LinkId=560369 ?>
+  <?define NetFx46EulaLink = https://go.microsoft.com/fwlink/?LinkID=558772 ?>
   <?define NetFx46WebId = NetFx46Web ?>
   <?define NetFx46RedistId = NetFx46Redist ?>
 
@@ -36,9 +36,8 @@
 
     <PackageGroup Id="$(var.NetFx46WebId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx46FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx46FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx46FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx46FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx46FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx46WebDetectCondition)"
           InstallCondition="!(wix.NetFx46WebInstallCondition)"
@@ -46,13 +45,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx46FullLog">
+        <ExePackagePayload 
+          Name="!(wix.NetFx46WebPackageDirectory)NDP46-KB3045560-Web.exe"
           DownloadUrl="$(var.NetFx46WebLink)"
-          LogPathVariable="NetFx46FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx46WebPackageDirectory)NDP46-KB3045560-Web.exe">
-        <RemotePayload 
           Description="Microsoft .NET Framework 4.6 Setup" 
-          Hash="480CA134B9E3F2437DF10719D5A8C77DDEC0A4F1" 
+          Hash="CAA5F4D4DB0C9DF34252FCB74CF7762214F69D2419865EBC1E6717E6B1348E59A7599A8DECAAB5CEE6974E59D1AE5A749F8C4EC07C8E4C80C90E77B996B3B205" 
           ProductName="Microsoft .NET Framework 4.6" 
           Size="1497400" 
           Version="4.6.81.0" />
@@ -77,9 +75,8 @@
 
     <PackageGroup Id="$(var.NetFx46RedistId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx46FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx46FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx46FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx46FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx46FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx46RedistDetectCondition)"
           InstallCondition="!(wix.NetFx46RedistInstallCondition)"
@@ -87,13 +84,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx46FullLog">
+        <ExePackagePayload
+          Name="!(wix.NetFx46RedistPackageDirectory)NDP46-KB3045557-x86-x64-AllOS-ENU.exe"
           DownloadUrl="$(var.NetFx46RedistLink)"
-          LogPathVariable="NetFx46FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx46RedistPackageDirectory)NDP46-KB3045557-x86-x64-AllOS-ENU.exe">
-        <RemotePayload
           Description="Microsoft .NET Framework 4.6 Setup" 
-          Hash="3049A85843EAF65E89E2336D5FE6E85E416797BE" 
+          Hash="C6FC54F648F822515ADACB4C27E0A6DBD6A3EAF2BA3F069C0002750894ECC453EBED8BC8D4FF2AFD73C7B3445C1DA18D43FE361EA5195AE8522249DF36B84B7E" 
           ProductName="Microsoft .NET Framework 4.6" 
           Size="65444688" 
           Version="4.6.81.0" />

--- a/src/wixlib/NetFx461.wxs
+++ b/src/wixlib/NetFx461.wxs
@@ -14,9 +14,9 @@
     -->
 
   <?define NetFx461MinRelease = 394254 ?>
-  <?define NetFx461WebLink = http://go.microsoft.com/fwlink/?LinkId=671728 ?>
-  <?define NetFx461RedistLink = http://go.microsoft.com/fwlink/?LinkId=671743 ?>
-  <?define NetFx461EulaLink = http://referencesource.microsoft.com/license.html ?>
+  <?define NetFx461WebLink = https://go.microsoft.com/fwlink/?LinkId=671728 ?>
+  <?define NetFx461RedistLink = https://go.microsoft.com/fwlink/?LinkId=671743 ?>
+  <?define NetFx461EulaLink = https://referencesource.microsoft.com/license.html ?>
   <?define NetFx461WebId = NetFx461Web ?>
   <?define NetFx461RedistId = NetFx461Redist ?>
 
@@ -35,9 +35,8 @@
 
     <PackageGroup Id="$(var.NetFx461WebId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx461FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx461FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx461FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx461FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx461FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx461WebDetectCondition)"
           InstallCondition="!(wix.NetFx461WebInstallCondition)"
@@ -45,13 +44,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx461FullLog">
+        <ExePackagePayload 
+          Name="!(wix.NetFx461WebPackageDirectory)NDP461-KB3102438-Web.exe"
           DownloadUrl="$(var.NetFx461WebLink)"
-          LogPathVariable="NetFx461FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx461WebPackageDirectory)NDP461-KB3102438-Web.exe">
-        <RemotePayload 
           Description="Microsoft .NET Framework 4.6.1 Setup" 
-          Hash="EE88B05232F43B517D4A368F7EE5065CDE7F67FA" 
+          Hash="97C4DD638E2E0324D60BDD1D7BE85603EDBF969898469A524FB271EBA5E22B78CA67DB1F568F5C45393381F1E76408C366AD4A68A7BB00E23D1FB820E67DE99E" 
           ProductName="Microsoft .NET Framework 4.6.1" 
           Size="1424328" 
           Version="4.6.1055.0" />
@@ -76,9 +74,8 @@
 
     <PackageGroup Id="$(var.NetFx461RedistId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx461FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx461FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx461FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx461FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx461FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx461RedistDetectCondition)"
           InstallCondition="!(wix.NetFx461RedistInstallCondition)"
@@ -86,13 +83,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx461FullLog">
+        <ExePackagePayload
+          Name="!(wix.NetFx461RedistPackageDirectory)NDP461-KB3102436-x86-x64-AllOS-ENU.exe"
           DownloadUrl="$(var.NetFx461RedistLink)"
-          LogPathVariable="NetFx461FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx461RedistPackageDirectory)NDP461-KB3102436-x86-x64-AllOS-ENU.exe">
-        <RemotePayload
           Description="Microsoft .NET Framework 4.6.1 Setup" 
-          Hash="83D048D171FF44A3CAD9B422137656F585295866" 
+          Hash="43BEF5EB278CF0954EAE1A6FEEC5A9852B932270508DD10647B9EA32DFD3832ECB58172B28707216709705BF0013FCEBB0B39DB31E38786FC2DAE219622EA00F" 
           ProductName="Microsoft .NET Framework 4.6.1" 
           Size="67681000" 
           Version="4.6.1055.0" />

--- a/src/wixlib/NetFx462.wxs
+++ b/src/wixlib/NetFx462.wxs
@@ -14,9 +14,9 @@
     -->
 
   <?define NetFx462MinRelease = 394802 ?>
-  <?define NetFx462WebLink = http://go.microsoft.com/fwlink/?LinkId=780596 ?>
-  <?define NetFx462RedistLink = http://go.microsoft.com/fwlink/?LinkId=780600 ?>
-  <?define NetFx462EulaLink = http://referencesource.microsoft.com/license.html ?>
+  <?define NetFx462WebLink = https://go.microsoft.com/fwlink/?LinkId=780596 ?>
+  <?define NetFx462RedistLink = https://go.microsoft.com/fwlink/?LinkId=780600 ?>
+  <?define NetFx462EulaLink = https://referencesource.microsoft.com/license.html ?>
   <?define NetFx462WebId = NetFx462Web ?>
   <?define NetFx462RedistId = NetFx462Redist ?>
 
@@ -35,9 +35,8 @@
 
     <PackageGroup Id="$(var.NetFx462WebId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx462FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx462FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx462FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx462FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx462FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx462WebDetectCondition)"
           InstallCondition="!(wix.NetFx462WebInstallCondition)"
@@ -45,13 +44,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx462FullLog">
+        <ExePackagePayload 
+          Name="!(wix.NetFx462WebPackageDirectory)NDP462-KB3151802-Web.exe"
           DownloadUrl="$(var.NetFx462WebLink)"
-          LogPathVariable="NetFx462FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx462WebPackageDirectory)NDP462-KB3151802-Web.exe">
-        <RemotePayload 
           Description="Microsoft .NET Framework 4.6.2 Setup" 
-          Hash="C42E6ED280290648BBD59F664008852F4CFE4548" 
+          Hash="31D7081BFFEEB5F32457096E51A29236306E5D971DE7EDB80A51188BCCDA9B9F17F0C3593D30828FC140B7A023F5B6842BC922F2023C7B8EA3786C2DBEC40472" 
           ProductName="Microsoft .NET Framework 4.6.2" 
           Size="1429344" 
           Version="4.6.1590.0" />
@@ -76,9 +74,8 @@
 
     <PackageGroup Id="$(var.NetFx462RedistId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx462FullLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx462FullLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx462FullLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx462FullLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx462FullLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx462RedistDetectCondition)"
           InstallCondition="!(wix.NetFx462RedistInstallCondition)"
@@ -86,13 +83,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx462FullLog">
+        <ExePackagePayload
+          Name="!(wix.NetFx462RedistPackageDirectory)NDP462-KB3151800-x86-x64-AllOS-ENU.exe"
           DownloadUrl="$(var.NetFx462RedistLink)"
-          LogPathVariable="NetFx462FullLog"
-          Compressed="no"
-          Name="!(wix.NetFx462RedistPackageDirectory)NDP462-KB3151800-x86-x64-AllOS-ENU.exe">
-        <RemotePayload
           Description="Microsoft .NET Framework 4.6.2 Setup" 
-          Hash="A70F856BDA33D45AD0A8AD035F73092441715431" 
+          Hash="E183B33F93FD5F9AA93A1EC02103D2548CA22E3447EF2CEEDE89A5DEBEFC4F2C20990567EB17AFA412E0698D577ADDA373E433847EC8B79EC04BE3C86EDD9F0E" 
           ProductName="Microsoft .NET Framework 4.6.2" 
           Size="62008080" 
           Version="4.6.1590.0" />

--- a/src/wixlib/NetFx47.wxs
+++ b/src/wixlib/NetFx47.wxs
@@ -2,7 +2,6 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <!--

--- a/src/wixlib/NetFx471.wxs
+++ b/src/wixlib/NetFx471.wxs
@@ -2,7 +2,6 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <!--

--- a/src/wixlib/NetFx472.wxs
+++ b/src/wixlib/NetFx472.wxs
@@ -33,9 +33,8 @@
 
     <PackageGroup Id="$(var.NetFx472WebId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx472WebLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx472WebLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx472WebLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx472WebLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx472WebLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx472WebDetectCondition)"
           InstallCondition="!(wix.NetFx472WebInstallCondition)"
@@ -43,13 +42,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx472WebLog">
+        <ExePackagePayload
+          Name="!(wix.NetFx472WebPackageDirectory)NDP472-KB4054531-Web.exe"
           DownloadUrl="$(var.NetFx472WebLink)"
-          LogPathVariable="NetFx472WebLog"
-          Compressed="no"
-          Name="!(wix.NetFx472WebPackageDirectory)NDP472-KB4054531-Web.exe">
-        <RemotePayload
           Description="Microsoft .NET Framework 4.7.2 Setup"
-          Hash="CEDBBF404B166A5E72D035760BCB0FA508E4F4CB"
+          Hash="37006954E3AFE07FB02D24894CC34794618B78C27A1B514818985B6CC1FA3E896ED99BA2E4AAC3F6469D263819BD94EE70E7113946C51BA83C93B74826FC8FA8"
           ProductName="Microsoft .NET Framework 4.7.2"
           Size="1432848"
           Version="4.7.3081.0" />
@@ -74,9 +72,8 @@
 
     <PackageGroup Id="$(var.NetFx472RedistId)">
       <ExePackage
-          InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx472RedistLog].html&quot;"
-          RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx472RedistLog].html&quot;"
-          UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx472RedistLog].html&quot;"
+          InstallArguments="/q /norestart /log &quot;[NetFx472RedistLog].html&quot;"
+          UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx472RedistLog].html&quot;"
           PerMachine="yes"
           DetectCondition="!(wix.NetFx472RedistDetectCondition)"
           InstallCondition="!(wix.NetFx472RedistInstallCondition)"
@@ -84,13 +81,12 @@
           Vital="yes"
           Permanent="yes"
           Protocol="netfx4"
+          LogPathVariable="NetFx472RedistLog">
+        <ExePackagePayload
+          Name="!(wix.NetFx472RedistPackageDirectory)NDP472-KB4054530-x86-x64-AllOS-ENU.exe"
           DownloadUrl="$(var.NetFx472RedistLink)"
-          LogPathVariable="NetFx472RedistLog"
-          Compressed="no"
-          Name="!(wix.NetFx472RedistPackageDirectory)NDP472-KB4054530-x86-x64-AllOS-ENU.exe">
-        <RemotePayload
           Description="Microsoft .NET Framework 4.7.2 Setup"
-          Hash="31FC0D305A6F651C9E892C98EB10997AE885EB1E"
+          Hash="36F295ED19A5BD5C5F05803BA26EFD17D419ABC7A791312AD011B63A4402492529AED0FB4D45FF1F74381079A310B33649C9C56C36E815B12E79ECD671897489"
           ProductName="Microsoft .NET Framework 4.7.2"
           Size="83943272"
           Version="4.7.3081.0" />

--- a/src/wixlib/NetFx48.wxs
+++ b/src/wixlib/NetFx48.wxs
@@ -33,9 +33,8 @@
 
         <PackageGroup Id="$(var.NetFx48WebId)">
             <ExePackage
-                InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48WebLog].html&quot;"
-                RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48WebLog].html&quot;"
-                UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48WebLog].html&quot;"
+                InstallArguments="/q /norestart /log &quot;[NetFx48WebLog].html&quot;"
+                UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx48WebLog].html&quot;"
                 PerMachine="yes"
                 DetectCondition="!(wix.NetFx48WebDetectCondition)"
                 InstallCondition="!(wix.NetFx48WebInstallCondition)"
@@ -43,13 +42,12 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="netfx4"
-                DownloadUrl="$(var.NetFx48WebLink)"
-                LogPathVariable="NetFx48WebLog"
-                Compressed="no"
-                Name="!(wix.NetFx48WebPackageDirectory)ndp48-web.exe">
-                <RemotePayload
+                LogPathVariable="NetFx48WebLog">
+                <ExePackagePayload
+                  Name="!(wix.NetFx48WebPackageDirectory)ndp48-web.exe"
+                  DownloadUrl="$(var.NetFx48WebLink)"
                   Description="Microsoft .NET Framework 4.8 Setup"
-                  Hash="5A84A8E612E270E27D0061D58DB6B470153BE1F9" 
+                  Hash="E18E3DB30A0AB2B51F34A9B7EBCEC0FD7B015F74B4525643C170FDE73EE94BA4092E3A82C98BCAE4AEBF48009BA8B6E7FA60B89AB917D8F28E74E84DB9D8CF21" 
                   ProductName="Microsoft .NET Framework 4.8"
                   Size="1479400" 
                   Version="4.8.3928.0" />
@@ -74,9 +72,8 @@
 
         <PackageGroup Id="$(var.NetFx48RedistId)">
             <ExePackage
-                InstallArguments="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48RedistLog].html&quot;"
-                RepairArguments="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48RedistLog].html&quot;"
-                UninstallArguments="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48RedistLog].html&quot;"
+                InstallArguments="/q /norestart /log &quot;[NetFx48RedistLog].html&quot;"
+                UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx48RedistLog].html&quot;"
                 PerMachine="yes"
                 DetectCondition="!(wix.NetFx48RedistDetectCondition)"
                 InstallCondition="!(wix.NetFx48RedistInstallCondition)"
@@ -84,13 +81,12 @@
                 Vital="yes"
                 Permanent="yes"
                 Protocol="netfx4"
-                DownloadUrl="$(var.NetFx48RedistLink)"
-                LogPathVariable="NetFx48RedistLog"
-                Compressed="no"
-                Name="!(wix.NetFx48RedistPackageDirectory)ndp48-x86-x64-allos-enu.exe">
-                <RemotePayload
+                LogPathVariable="NetFx48RedistLog">
+                <ExePackagePayload
+                  Name="!(wix.NetFx48RedistPackageDirectory)ndp48-x86-x64-allos-enu.exe"
+                  DownloadUrl="$(var.NetFx48RedistLink)"
                   Description="Microsoft .NET Framework 4.8 Setup"
-                  Hash="8DD233698D5EB4609B86C2AC917279FE39E0EF4C" 
+                  Hash="B758812388CD1BE1E6994B58267088FE6C22961D875153CC8B924DFC590F681AF85D750AA412571745B3872CADA56E2A45C4328CFDC5EE8E201743830614609E" 
                   ProductName="Microsoft .NET Framework 4.8"
                   Size="117380440" 
                   Version="4.8.3928.0" />


### PR DESCRIPTION
Update dependencies and integrate changes.
Remove unsupported versions of .NET Framework.
Update to latest 3.1 .NET Core.
Remove /ChainingPackage from .NET Framework args.
Remove RepairArguments from .NET Framework packages.
Make all package urls https.

https://github.com/wixtoolset/issues/issues/3992
https://github.com/wixtoolset/issues/issues/4183
Fixes https://github.com/wixtoolset/issues/issues/5374
Fixes https://github.com/wixtoolset/issues/issues/5615
https://github.com/wixtoolset/issues/issues/5762